### PR TITLE
Update fastqc, trim_galore to improve cache-ability in preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Tweaked fastqc and trim\_galore tools to make them cache-able
+
 ## [4.2.0] - 2019-04-04
 
 ### Added

--- a/tools/fastqc.cwl
+++ b/tools/fastqc.cwl
@@ -12,13 +12,22 @@ hints:
         s:citation: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 
 requirements:
+  # Place input file into output directory, because fastqc
+  # will by default write to the same directory as the input.
+  # While fastqc does have a -o option for specifying the
+  # output directory, it causes the command-line to change
+  # from one run to the next, and therefore cannot be cached.
+  - class: InitialWorkDirRequirement
+    listing:
+      - $(inputs.input_fastq_file)
   - class: InlineJavascriptRequirement
-
 inputs:
   input_fastq_file:
     type: File
     inputBinding:
       position: 4
+      valueFrom: $(self.basename)
+
   noextract:
     type: boolean
     default: true
@@ -39,7 +48,6 @@ inputs:
       position: 5
       prefix: "--threads"
 
-
 outputs:
   output_qc_report:
     type: File
@@ -49,10 +57,7 @@ outputs:
 baseCommand: fastqc
 arguments:
   - valueFrom: $('/tmp')
-    prefix: "--dir"
-    position: 5
-  - valueFrom: $(runtime.outdir)
-    prefix: "-o"
+    prefix: "--dir" # Temp directory to use when writing report images
     position: 5
 
 $namespaces:

--- a/tools/trim_galore.cwl
+++ b/tools/trim_galore.cwl
@@ -43,10 +43,6 @@ outputs:
       glob: "*_trimming_report.txt"
 
 baseCommand: trim_galore
-arguments:
-  - valueFrom: $(runtime.outdir)
-    prefix: "-o"
-    position: 2
 
 $namespaces:
   s: https://schema.org/


### PR DESCRIPTION
Full description in https://github.com/bespin-workflows/exomeseq-gatk4/pull/9. These commits were copied from exomeseq-gatk4 using `git format-patch` and `git am`

```
cd exomeseq-gatk4
git format-patch develop
cd ../exomeseq-gatk3
git am ../exomeseq-gatk4/*.patch
```

