### PR TITLE
VariantRecalibrator parameter changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updates parameters used by VariantRecalibrator to help with `No data found` errors.
 - Tweaked fastqc and trim\_galore tools to make them cache-able
 
 ## [4.2.0] - 2019-04-04

--- a/subworkflows/exomeseq-02-variantdiscovery.cwl
+++ b/subworkflows/exomeseq-02-variantdiscovery.cwl
@@ -112,7 +112,7 @@ steps:
     in:
       study_type: study_type
       base_annotations:
-        default: ["QD","FS","MQ","SOR","MQRankSum","ReadPosRankSum"]
+        default: ["DP","QD","FS","MQ","SOR","MQRankSum","ReadPosRankSum"]
     out:
       - annotations
   variant_recalibration_snps:
@@ -156,7 +156,7 @@ steps:
     in:
       study_type: study_type
       base_annotations:
-        default: ["QD","FS","MQ","MQRankSum","ReadPosRankSum"]
+        default: ["QD","DP","FS","SOR","MQRankSum","ReadPosRankSum"]
     out:
       - annotations
   variant_recalibration_indels:

--- a/subworkflows/exomeseq-02-variantdiscovery.cwl
+++ b/subworkflows/exomeseq-02-variantdiscovery.cwl
@@ -112,7 +112,7 @@ steps:
     in:
       study_type: study_type
       base_annotations:
-        default: ["DP","QD","FS","MQ","SOR","MQRankSum","ReadPosRankSum"]
+        default: ["QD","FS","MQ","SOR","MQRankSum","ReadPosRankSum"]
     out:
       - annotations
   variant_recalibration_snps:
@@ -156,7 +156,7 @@ steps:
     in:
       study_type: study_type
       base_annotations:
-        default: ["QD","DP","FS","SOR","MQRankSum","ReadPosRankSum"]
+        default: ["QD","FS","SOR","MQRankSum","ReadPosRankSum"]
     out:
       - annotations
   variant_recalibration_indels:

--- a/tools/GATK-VariantRecalibrator-SNPs.cwl
+++ b/tools/GATK-VariantRecalibrator-SNPs.cwl
@@ -86,7 +86,7 @@ inputs: # position 0, for java args, 1 for the jar, 2 for the tool itself
     - .idx
     inputBinding:
       position: 2
-      prefix: -resource:omni,known=false,training=true,truth=false,prior=12.0
+      prefix: -resource:omni,known=false,training=true,truth=true,prior=12.0
     doc: omni reference data
 
   resource_1kg:


### PR DESCRIPTION
Parameter changes based on bioinformatician feedback to help with `No data found` errors during variant recalibration steps. In testing previously failed data these changes corrected some `No data found` errors but not all. Testing was done by running just exomeseq-02-variantdiscovery.cwl.